### PR TITLE
Check dimension of gram matrix (#87)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -271,6 +271,25 @@ end
         @test model.coefs ≈ model₂.coefs
         @test model.SVs.indices ≈ model₂.SVs.indices
     end
+
+    @testset "Malformed prediction" begin
+        X = [-2 -1 -1 1 1 2;
+            -1 -1 -2 1 2 1]
+        y = [1, 1, 1, 2, 2, 2]
+
+        T = [-1 2 3;
+            -1 2 2]
+
+        K = X' * X
+
+        model = svmtrain(K, y, kernel=Kernel.Precomputed)
+
+        KK = X' * T
+
+        KK_malformed = KK[1:1,:]
+
+        @test_throws DimensionMismatch svmpredict(model, KK_malformed)
+    end
 end
 
 end  # @testset "LIBSVM"


### PR DESCRIPTION
* Implement dimension check for prediction gram matrix

* Add tests for gram matrix dimension check

* Disallow providing only support vector related entries

* Adjust error message

* Minor style changes

Resolves #85